### PR TITLE
Add HUD to build area

### DIFF
--- a/src/main/java/worldofzuul/presentation/BuildAreaController.java
+++ b/src/main/java/worldofzuul/presentation/BuildAreaController.java
@@ -11,16 +11,23 @@ import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.Label;
 import javafx.stage.Stage;
 import worldofzuul.Game;
 
 import java.io.IOException;
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
 
 public class BuildAreaController {
     @FXML
     private Button btnHouse;
+
     @FXML
     private Group buildArea;
+
+    @FXML
+    private Label renewable_label, fossil_label, battery_label;
 
     ObservableList<BuildItem> buildItems = FXCollections.observableArrayList();
 
@@ -47,6 +54,11 @@ public class BuildAreaController {
 
         // Make sure changes in buildItems are reflected in GUI
         Bindings.bindContent(buildArea.getChildren(), buildItems);
+
+        // Set label values
+        renewable_label.setText(String.format("Renewable energy: %s pr. year", humanReadableWattHoursSI(Game.instance.getBuildArea().getYearlyEnergyProductionRenewable())));
+        fossil_label.setText(String.format("Fossil energy: %s", humanReadableWattHoursSI(Game.instance.getBuildArea().getYearlyEnergyProductionFossil())));
+        battery_label.setText(String.format("Battery storage: %s", humanReadableWattHoursSI(Game.instance.getBuildArea().getTotalBatteryCapacity())));
     }
 
     /**
@@ -57,5 +69,28 @@ public class BuildAreaController {
 
         Stage window = (Stage) btnHouse.getScene().getWindow();
         window.setScene(new Scene(root, 600, 400));
+    }
+
+    /**
+     * TODO: Should probably be moved to a seperate helper class
+     * TODO: Could be generalized to all units
+     * Based on: https://stackoverflow.com/a/3758880
+     *
+     * @param kWh energy in kWh
+     * @return energy in human-readable unit
+     */
+    private static String humanReadableWattHoursSI(double kWh) {
+        long wH = Math.round(kWh * 1000);
+
+        if (-1000 < wH && wH < 1000) {
+            return wH + " Wh";
+        }
+
+        CharacterIterator ci = new StringCharacterIterator("kMGTPE");
+        while (wH <= -999_950 || wH >= 999_950) {
+            wH /= 1000;
+            ci.next();
+        }
+        return String.format("%.1f %cWh", wH / 1000.0, ci.current());
     }
 }

--- a/src/main/resources/worldofzuul.presentation/buildArea.fxml
+++ b/src/main/resources/worldofzuul.presentation/buildArea.fxml
@@ -5,19 +5,44 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.shape.Rectangle?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Group?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
 
+<?import javafx.scene.shape.Rectangle?>
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0"
             prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="worldofzuul.presentation.BuildAreaController">
     <Group>
-        <ImageView fitHeight="415.0" fitWidth="600" pickOnBounds="true" preserveRatio="false">
+        <ImageView fitHeight="415.0" fitWidth="600" pickOnBounds="true">
             <Image url="@../images/SolVindGrund.png"/>
         </ImageView>
-        <Rectangle fx:id="background"/>
         <Group fx:id="buildArea"/>
     </Group>
-    <Button fx:id="btnHouse" layoutX="533.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleBtnHouse"
-            text="Back"/>
+    <HBox AnchorPane.bottomAnchor="5" AnchorPane.leftAnchor="5" AnchorPane.rightAnchor="5" maxHeight="-Infinity"
+          prefHeight="30.0"
+          spacing="5.0"
+          style="-fx-background-color: rgba(115, 115, 115, 0.8); -fx-background-radius: 5; -fx-alignment: center;"
+    >
+        <opaqueInsets>
+            <Insets/>
+        </opaqueInsets>
+        <StackPane.margin>
+            <Insets bottom="5.0" left="5.0" right="5.0"/>
+        </StackPane.margin>
+        <Label fx:id="renewable_label" text="Renewable energy: 115kWh pr. year" textFill="WHITE"/>
+        <Separator orientation="VERTICAL"/>
+        <Label fx:id="fossil_label" text="Fossil energy: 115kWh" textFill="WHITE"/>
+        <Separator orientation="VERTICAL"/>
+        <Label fx:id="battery_label" text="Battery storage: 15kWh" textFill="WHITE"/>
+    </HBox>
+    <Button fx:id="btnHouse" mnemonicParsing="false" onAction="#handleBtnHouse" text="Back"
+            AnchorPane.topAnchor="10" AnchorPane.rightAnchor="10">
+    </Button>
 </AnchorPane>


### PR DESCRIPTION
This PR adds a HUD to the build area, to display useful information about the players purchased energy sources. It has also implemented a method to convert the energy production to human readable units. When the player only has a single small solar panel it uses kWh and when the player adds more energy sources it will use MWh and continue up for larger units. 

<img width="668" alt="Screenshot 2021-12-04 at 02 26 02" src="https://user-images.githubusercontent.com/20731972/144691631-2413bf2c-b887-4023-a1a5-90c7900f808c.png">

