### PR TITLE
Added miniature build grid on house scene

### DIFF
--- a/src/main/java/worldofzuul/presentation/BuildAreaController.java
+++ b/src/main/java/worldofzuul/presentation/BuildAreaController.java
@@ -30,7 +30,7 @@ public class BuildAreaController {
      */
     @FXML
     private void initialize() {
-        this.buildArea.getChildren().add(new BuildGrid(new Point2D(18, 36), 20));
+        this.buildArea.getChildren().add(new BuildGrid(new Point2D(18, 36), 20, 27, 17));
 
         // Set label values
         renewable_label.setText(String.format("Renewable energy: %s pr. year", humanReadableWattHoursSI(Game.instance.getBuildArea().getYearlyEnergyProductionRenewable())));

--- a/src/main/java/worldofzuul/presentation/BuildAreaController.java
+++ b/src/main/java/worldofzuul/presentation/BuildAreaController.java
@@ -1,11 +1,7 @@
 package worldofzuul.presentation;
 
-import javafx.beans.binding.Bindings;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.geometry.BoundingBox;
 import javafx.geometry.Point2D;
 import javafx.scene.Group;
 import javafx.scene.Parent;
@@ -24,36 +20,17 @@ public class BuildAreaController {
     private Button btnHouse;
 
     @FXML
-    private Group buildArea;
-
-    @FXML
     private Label renewable_label, fossil_label, battery_label;
 
-    ObservableList<BuildItem> buildItems = FXCollections.observableArrayList();
-
-    // Size and position of buildarea
-    private Point2D gridOffset = new Point2D(18, 36);
-    private int gridWidth = 27;
-    private int gridHeight = 17;
-    private BoundingBox buildAreaBounds = new BoundingBox(gridOffset.getX(), gridOffset.getY(), gridWidth * BuildItem.gridSize, gridHeight * BuildItem.gridSize);
+    @FXML
+    private Group buildArea;
 
     /**
      * Initialize is called after the FXML attributes are saturates
      */
     @FXML
-    public void initialize() {
-        // Setup build area component
-        buildArea.setTranslateX(gridOffset.getX());
-        buildArea.setTranslateY(gridOffset.getY());
-        buildArea.setUserData(buildAreaBounds);
-
-        // Load in energysources from build area
-        for (var source : Game.instance.getBuildArea().getEnergySources()) {
-            buildItems.add(new BuildItem(source));
-        }
-
-        // Make sure changes in buildItems are reflected in GUI
-        Bindings.bindContent(buildArea.getChildren(), buildItems);
+    private void initialize() {
+        this.buildArea.getChildren().add(new BuildGrid(new Point2D(18, 36), 20));
 
         // Set label values
         renewable_label.setText(String.format("Renewable energy: %s pr. year", humanReadableWattHoursSI(Game.instance.getBuildArea().getYearlyEnergyProductionRenewable())));

--- a/src/main/java/worldofzuul/presentation/BuildGrid.java
+++ b/src/main/java/worldofzuul/presentation/BuildGrid.java
@@ -12,14 +12,16 @@ public class BuildGrid extends Group {
     private Point2D offset;
 
     private double gridSize;
-    private int gridWidth = 27;
-    private int gridHeight = 17;
+    private int gridWidth;
+    private int gridHeight;
 
     ObservableList<BuildItem> buildItems = FXCollections.observableArrayList();
 
-    public BuildGrid(Point2D offset, double gridSize) {
+    public BuildGrid(Point2D offset, double gridSize, int gridWidth, int gridHeight) {
         this.offset = offset;
         this.gridSize = gridSize;
+        this.gridWidth = gridWidth;
+        this.gridHeight = gridHeight;
 
         this.setTranslateX(this.offset.getX());
         this.setTranslateY(this.offset.getY());
@@ -27,7 +29,9 @@ public class BuildGrid extends Group {
 
         // Load in energysources from build area
         for (var source : Game.instance.getBuildArea().getEnergySources()) {
-            buildItems.add(new BuildItem(source, getGridSize()));
+            // If the energysource is outside the clip area, we clip them off
+            if (source.getPosX() < gridWidth && source.getPosY() < gridHeight)
+                buildItems.add(new BuildItem(source, getGridSize()));
         }
 
         // Make sure changes in buildItems are reflected in GUI

--- a/src/main/java/worldofzuul/presentation/BuildGrid.java
+++ b/src/main/java/worldofzuul/presentation/BuildGrid.java
@@ -1,0 +1,44 @@
+package worldofzuul.presentation;
+
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Point2D;
+import javafx.scene.Group;
+import worldofzuul.Game;
+
+public class BuildGrid extends Group {
+    private Point2D offset;
+
+    private double gridSize;
+    private int gridWidth = 27;
+    private int gridHeight = 17;
+
+    ObservableList<BuildItem> buildItems = FXCollections.observableArrayList();
+
+    public BuildGrid(Point2D offset, double gridSize) {
+        this.offset = offset;
+        this.gridSize = gridSize;
+
+        this.setTranslateX(this.offset.getX());
+        this.setTranslateY(this.offset.getY());
+        this.setUserData(getBuildAreaBounds());
+
+        // Load in energysources from build area
+        for (var source : Game.instance.getBuildArea().getEnergySources()) {
+            buildItems.add(new BuildItem(source, getGridSize()));
+        }
+
+        // Make sure changes in buildItems are reflected in GUI
+        Bindings.bindContent(getChildren(), buildItems);
+    }
+
+    public double getGridSize() {
+        return gridSize;
+    }
+
+    public BoundingBox getBuildAreaBounds() {
+        return new BoundingBox(this.offset.getX(), this.offset.getY(), gridWidth * getGridSize(), gridHeight * getGridSize());
+    }
+}

--- a/src/main/java/worldofzuul/presentation/SceneController.java
+++ b/src/main/java/worldofzuul/presentation/SceneController.java
@@ -2,6 +2,8 @@ package worldofzuul.presentation;
 
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Point2D;
+import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
@@ -12,7 +14,6 @@ import javafx.stage.Stage;
 import worldofzuul.Game;
 import worldofzuul.Input.Command;
 import worldofzuul.Input.CommandWord;
-import worldofzuul.Input.CommandWords;
 import worldofzuul.Rooms.Shops.Shop;
 
 import java.io.IOException;
@@ -29,6 +30,16 @@ public class SceneController {
 
     @FXML
     private URL location;
+
+    @FXML
+    private Group buildArea;
+
+    @FXML
+    private void initialize() {
+        if (buildArea != null) {
+            this.buildArea.getChildren().add(new BuildGrid(new Point2D(48, 112), 8));
+        }
+    }
 
     //methods for window change
     public void handleBtnHouse() throws Exception {

--- a/src/main/java/worldofzuul/presentation/SceneController.java
+++ b/src/main/java/worldofzuul/presentation/SceneController.java
@@ -37,7 +37,7 @@ public class SceneController {
     @FXML
     private void initialize() {
         if (buildArea != null) {
-            this.buildArea.getChildren().add(new BuildGrid(new Point2D(48, 112), 8));
+            this.buildArea.getChildren().add(new BuildGrid(new Point2D(48, 112), 8, 13, 13));
         }
     }
 

--- a/src/main/resources/worldofzuul.presentation/buildArea.fxml
+++ b/src/main/resources/worldofzuul.presentation/buildArea.fxml
@@ -15,7 +15,6 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 
-<?import javafx.scene.shape.Rectangle?>
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0"
             prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="worldofzuul.presentation.BuildAreaController">

--- a/src/main/resources/worldofzuul.presentation/house.fxml
+++ b/src/main/resources/worldofzuul.presentation/house.fxml
@@ -6,48 +6,64 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.Font?>
+<?import javafx.scene.Group?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="worldofzuul.presentation.SceneController">
-   <children>
-      <ImageView fx:id="houseImage" fitHeight="400.0" fitWidth="600.0" pickOnBounds="true">
-         <image>
-            <Image url="@../images/SemesterProjektMapNY.png" />
-         </image>
-      </ImageView>
-      <Label layoutX="311.0" layoutY="67.0" text="House">
-         <font>
-            <Font size="14.0" />
-         </font></Label>
-      <Button fx:id="btnNextYear" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleBtnNextYear" text="Next Year" />
-      <Button fx:id="btnHelp" layoutX="100.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleBtnHelp" text="Help" />
-      <Label fx:id="labelBuildArea" layoutX="68.0" layoutY="235.0" text="Build Area" onMouseClicked="#handleLabelBuildArea">
-         <font>
-            <Font size="14.0" />
-         </font>
-      </Label>
-      <Label layoutX="463.0" layoutY="158.0" text="Windturbine Shop">
-         <font>
-            <Font size="14.0" />
-         </font>
-      </Label>
-      <Label layoutX="485.0" layoutY="320.0" text="Retail Shop">
-         <font>
-            <Font size="14.0" />
-         </font>
-      </Label>
-      <Button fx:id="btnWindturbineShop" layoutX="494.0" layoutY="97.0" mnemonicParsing="false" onAction="#handleBtnWindturbineShop" prefHeight="46.0" prefWidth="52.0" style="-fx-opacity: 0;" text="Button" />
-      <Button fx:id="btnRetailShop" layoutX="494.0" layoutY="248.0" mnemonicParsing="false" onAction="#handleBtnRetailShop" prefHeight="53.0" prefWidth="52.0" style="-fx-opacity: 0;" text="Button" />
-      <Label layoutX="381.0" layoutY="320.0" text="Battery Shop">
-         <font>
-            <Font size="14.0" />
-         </font>
-      </Label>
-      <Label layoutX="350.0" layoutY="158.0" text="Solar Panel Shop">
-         <font>
-            <Font size="14.0" />
-         </font>
-      </Label>
-      <Button fx:id="btnBatteryShop" layoutX="411.0" layoutY="248.0" mnemonicParsing="false" onAction="#handleBtnBatteryShop" prefHeight="53.0" prefWidth="63.0" style="-fx-opacity: 0;" text="Button" />
-      <Button fx:id="btnSolarPanelShop" layoutX="411.0" layoutY="93.0" mnemonicParsing="false" onAction="#handleBtnSolarPanelShop" prefHeight="53.0" prefWidth="63.0" style="-fx-opacity: 0;" text="Button" />
-      </children>
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0"
+            prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="worldofzuul.presentation.SceneController">
+    <children>
+        <ImageView fx:id="houseImage" fitHeight="400.0" fitWidth="600.0" pickOnBounds="true">
+            <image>
+                <Image url="@../images/SemesterProjektMapNY.png"/>
+            </image>
+        </ImageView>
+        <Label layoutX="311.0" layoutY="67.0" text="House">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Button fx:id="btnNextYear" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleBtnNextYear"
+                text="Next Year"/>
+        <Button fx:id="btnHelp" layoutX="100.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleBtnHelp"
+                text="Help"/>
+        <Label fx:id="labelBuildArea" layoutX="68.0" layoutY="235.0" onMouseClicked="#handleLabelBuildArea"
+               text="Build Area">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Label layoutX="463.0" layoutY="158.0" text="Windturbine Shop">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Label layoutX="485.0" layoutY="320.0" text="Retail Shop">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Button fx:id="btnWindturbineShop" layoutX="494.0" layoutY="97.0" mnemonicParsing="false"
+                onAction="#handleBtnWindturbineShop" prefHeight="46.0" prefWidth="52.0" style="-fx-opacity: 0;"
+                text="Button"/>
+        <Button fx:id="btnRetailShop" layoutX="494.0" layoutY="248.0" mnemonicParsing="false"
+                onAction="#handleBtnRetailShop" prefHeight="53.0" prefWidth="52.0" style="-fx-opacity: 0;"
+                text="Button"/>
+        <Label layoutX="381.0" layoutY="320.0" text="Battery Shop">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Label layoutX="350.0" layoutY="158.0" text="Solar Panel Shop">
+            <font>
+                <Font size="14.0"/>
+            </font>
+        </Label>
+        <Button fx:id="btnBatteryShop" layoutX="411.0" layoutY="248.0" mnemonicParsing="false"
+                onAction="#handleBtnBatteryShop" prefHeight="53.0" prefWidth="63.0" style="-fx-opacity: 0;"
+                text="Button"/>
+        <Button fx:id="btnSolarPanelShop" layoutX="411.0" layoutY="93.0" mnemonicParsing="false"
+                onAction="#handleBtnSolarPanelShop" prefHeight="53.0" prefWidth="63.0" style="-fx-opacity: 0;"
+                text="Button"/>
+        <Group fx:id="buildArea" disable="true"/>
+    </children>
 </AnchorPane>


### PR DESCRIPTION
This PR adds a miniature build grid on house scene, with animated windmills and everything.

It also redoes how collision handling is done when dragging components. 

The build grid has been extracted to its own component, so it is used on both the build area and the house scene reducing code duplication. It has also been updated, such that it supports multiple grid resolutions/scales.

I am still not quite happy with the collision detection between the windmills, but it will have to do for now.

We also need to update the house texture or the build area texture, such that the have the same aspect ratio, otherwise the build items will be displayed outside of their build area on one of the screens. 

This is how it looks on the home screen:
<img width="712" alt="Screenshot 2021-12-05 at 00 16 39" src="https://user-images.githubusercontent.com/20731972/144727549-1f36222f-0e5f-41f0-86c9-3e09427d2fd2.png">


