### PR TITLE
Build area tooltip

### DIFF
--- a/src/main/java/worldofzuul/presentation/BuildAreaController.java
+++ b/src/main/java/worldofzuul/presentation/BuildAreaController.java
@@ -79,7 +79,7 @@ public class BuildAreaController {
      * @param kWh energy in kWh
      * @return energy in human-readable unit
      */
-    private static String humanReadableWattHoursSI(double kWh) {
+    public static String humanReadableWattHoursSI(double kWh) {
         long wH = Math.round(kWh * 1000);
 
         if (-1000 < wH && wH < 1000) {

--- a/src/main/java/worldofzuul/presentation/BuildItem.java
+++ b/src/main/java/worldofzuul/presentation/BuildItem.java
@@ -1,7 +1,6 @@
 package worldofzuul.presentation;
 
 import javafx.animation.Animation;
-import javafx.animation.AnimationTimer;
 import javafx.animation.Interpolator;
 import javafx.animation.RotateTransition;
 import javafx.geometry.BoundingBox;
@@ -37,7 +36,14 @@ public class BuildItem extends Parent {
         this.y = source.getPosY();
 
         // Set tooltip for the item
-        Tooltip t = new Tooltip(source.getDescription());
+        String tooltipDescription = String.join("\n",
+                source.getDescription(),
+                String.format("Total generation: %s", BuildAreaController.humanReadableWattHoursSI(source.getTotalGeneratedEnergy())),
+                String.format("Total returns: %s kr.", (int) source.getTotalGeneratedMoney()),
+                String.format("ROI: %.2f%%", 100 * source.getTotalGeneratedMoney() / source.getPrice())
+        );
+
+        Tooltip t = new Tooltip(tooltipDescription);
         Tooltip.install(this, t);
 
         // If the width or height hasn't been set, then use 1x1 to not break graphics


### PR DESCRIPTION
This improves upon the tooltip on the energy source, to display total energy generated, total money generated and the return on investment. This PR is marked as a draft, since we might want to add more to the tooltip.

This is how it looks:
<img width="712" alt="Screenshot 2021-12-06 at 22 01 23" src="https://user-images.githubusercontent.com/20731972/144921921-edd51e01-2b3c-418e-a4d8-c909be433777.png">
