### PR TITLE
Fix overlap with third buy button, by moving the notifications to the top right

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module worldofzuul {
     exports worldofzuul.Config to org.yaml.snakeyaml;
     exports worldofzuul.Items to org.yaml.snakeyaml;
 
+    exports worldofzuul.Exceptions;
     exports worldofzuul.Rooms;
     exports worldofzuul;
 }

--- a/src/main/java/worldofzuul/Game.java
+++ b/src/main/java/worldofzuul/Game.java
@@ -192,7 +192,11 @@ public class Game {
             case UNKNOWN -> System.out.println("I don't know what you mean...Please try again.");
             case BUY -> {
                 if (currentRoom instanceof Shop) {
-                    buyItem(command, (Shop) currentRoom);
+                    try {
+                        buyItem(command, (Shop) currentRoom);
+                    } catch (CannotBuyItemMoreThanOnceException e) {
+                        System.out.println(e.getMessage());
+                    }
                 } else {
                     System.out.println("You are not currently in a shop.");
                 }
@@ -257,7 +261,7 @@ public class Game {
      * @param command     Player input
      * @param currentShop The current shop the player is in
      */
-    public void buyItem(Command command, Shop currentShop) {
+    public void buyItem(Command command, Shop currentShop) throws CannotBuyItemMoreThanOnceException {
         if (!command.hasSecondWord()) {
             System.out.println("Buy what?");
             return;
@@ -288,8 +292,6 @@ public class Game {
             System.out.println("Please enter a valid number.");
         } catch (ReceiverForBoughtItemNotFoundException recieverForBoughtItemNotFound) {
             System.out.println("Could not buy that item");
-        } catch (CannotBuyItemMoreThanOnceException cannotBuyItemMoreThanOnce) {
-            System.out.println(cannotBuyItemMoreThanOnce.getMessage());
         }
     }
 
@@ -347,7 +349,7 @@ public class Game {
 
             // Step 8: Print to the player what happened(money, co2, sold energy, sales price)
             System.out.println("You are now in the year: " + gameYear);
-            System.out.println("Your emission for this year is: " + player.getRecapEnergyEmission().get(gameYear-1));
+            System.out.println("Your emission for this year is: " + player.getRecapEnergyEmission().get(gameYear - 1));
             System.out.println("Your total emission is: " + player.calculateEmission());
             System.out.println("Your earned money on sold energy: " + soldEnergyPrice);
             System.out.println("Your balance are:" + player.getPlayerEconomy());

--- a/src/main/java/worldofzuul/presentation/BuyButton.java
+++ b/src/main/java/worldofzuul/presentation/BuyButton.java
@@ -125,6 +125,9 @@ public class BuyButton extends Rectangle implements EventHandler<MouseEvent> {
                 .hideAfter(Duration.seconds(2))
                 .show();
 
+        // Do a y-offset, so the notification doesn't collide with the window border
+        n.getParent().getParent().getParent().setLayoutY(20);
+
         notificationsGraphic.add(n);
     }
 

--- a/src/main/java/worldofzuul/presentation/BuyButton.java
+++ b/src/main/java/worldofzuul/presentation/BuyButton.java
@@ -84,7 +84,7 @@ public class BuyButton extends Rectangle implements EventHandler<MouseEvent> {
         }
 
         // Check if we can buy the item
-        if (Game.instance.getPlayer().withdrawMoney(item.getPrice())) {
+        if (Game.instance.getPlayer().getPlayerEconomy() >= item.getPrice()) {
             Game.instance.buyItem(new Command(CommandWord.BUY, Integer.toString(itemIndex)), foundShop);
             playSuccessSound();
             showNotification("Success", "Bought " + item.getName());

--- a/src/main/java/worldofzuul/presentation/BuyButton.java
+++ b/src/main/java/worldofzuul/presentation/BuyButton.java
@@ -98,7 +98,7 @@ public class BuyButton extends Rectangle implements EventHandler<MouseEvent> {
     // This has to be static, since all buybuttons share the same static notification system
     // There might be another way to do this cleanly without using static, but this works
     private static final ArrayList<Node> notificationsGraphic = new ArrayList<>();
-    private final int maxNotifications = 6;
+    private final int maxNotifications = 3;
 
     private void showNotification(String title, String description) {
         // If we have too many notifications we hide the oldest ones, so the don't go outside the window
@@ -121,6 +121,7 @@ public class BuyButton extends Rectangle implements EventHandler<MouseEvent> {
                 .text(description)
                 .graphic(n)
                 .owner(this)
+                .position(Pos.TOP_RIGHT)
                 .hideAfter(Duration.seconds(2))
                 .show();
 
@@ -136,7 +137,7 @@ public class BuyButton extends Rectangle implements EventHandler<MouseEvent> {
     private void playSuccessSound() {
         Media sound = new Media(getClass().getClassLoader().getResource("coinsound.mp3").toExternalForm());
         MediaPlayer mediaPlayer = new MediaPlayer(sound);
-        mediaPlayer.setVolume(0.1);
+        mediaPlayer.setVolume(0.05);
         mediaPlayer.play();
     }
 

--- a/src/main/resources/worldofzuul.presentation/Battery shop.fxml
+++ b/src/main/resources/worldofzuul.presentation/Battery shop.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.text.*?>
 <?import worldofzuul.presentation.BuyButton?>
 
-<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="worldofzuul.presentation.SceneController">
+<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="worldofzuul.presentation.BatteryShopController">
     <ImageView fitHeight="400.0" fitWidth="600.0" pickOnBounds="true">
         <Image url="@../images/ShopOutline.png" />
     </ImageView>


### PR DESCRIPTION
This fixes the following issues:
- Notifications where blocking the buy button on the third coloums
- It was playing the coin sound when buying the second car or heatpump
- There was a double withdrawal issue
- Coin sound was still loud
- Added the price amount that is missing in the notification
<img width="712" alt="Screenshot 2021-12-08 at 14 57 12" src="https://user-images.githubusercontent.com/20731972/145220567-cc103a9e-673c-484a-96e5-45ffb3fb0269.png">
