### PR TITLE
Money to assetvalue

### DIFF
--- a/src/main/java/worldofzuul/presentation/BuyButton.java
+++ b/src/main/java/worldofzuul/presentation/BuyButton.java
@@ -119,10 +119,10 @@ public class BuyButton extends VBox implements EventHandler<MouseEvent> {
 
     private void updateMoneyLabel() {
         var moneyLabel = getParent().lookup("#moneys");
-        moneyLabel.setLayoutX(500);
-        moneyLabel.setLayoutY(25);
         // Instanceof also covers null checking
         if (moneyLabel instanceof Label) {
+            moneyLabel.setLayoutX(500);
+            moneyLabel.setLayoutY(25);
             ((Label) moneyLabel).setText(String.format("%.2fDKK", Game.instance.getPlayer().getPlayerEconomy()));
         }
     }

--- a/src/main/java/worldofzuul/presentation/RecapController.java
+++ b/src/main/java/worldofzuul/presentation/RecapController.java
@@ -13,16 +13,21 @@ public class RecapController {
     private Label emissionScore, moneyEarnedScore, money, highScore;
 
     @FXML
-    public void initialize(){
+    public void initialize() {
         double emission = Game.instance.getPlayer().calculateEmission();
         double moneyEarned = Game.instance.getSoldEnergyPrice();
         double excessMoney = Game.instance.getPlayer().getPlayerEconomy();
-        int highscore = (int)((50000/(emission/1000))+moneyEarned+excessMoney);
+        double assetValue = 0;
+        for (var source : Game.instance.getBuildArea().getEnergySources()) {
+            assetValue += source.getPrice();
+        }
+
+        int highscore = (int) ((50000 / (emission / 1000)) + moneyEarned + excessMoney);
 
 
         emissionScore.setText(decimalFormat.format(emission) + " kg CO\u2082");
         moneyEarnedScore.setText(decimalFormat.format(moneyEarned) + " DKK");
-        money.setText(decimalFormat.format(excessMoney) + " DKK");
+        money.setText(decimalFormat.format(excessMoney + assetValue) + " DKK");
         highScore.setText(String.valueOf(highscore));
     }
 }

--- a/src/main/resources/worldofzuul.presentation/recap.fxml
+++ b/src/main/resources/worldofzuul.presentation/recap.fxml
@@ -21,7 +21,7 @@
             <Font size="18.0" />
          </font>
       </Label>
-      <Label layoutX="270.0" layoutY="221.0" text="Money:">
+      <Label layoutX="270.0" layoutY="221.0" text="Total asset value:">
          <font>
             <Font size="18.0" />
          </font>


### PR DESCRIPTION
This changes the recap screen to show their entire asset value instead of just the monetary ones:
<img width="712" alt="Screenshot 2021-12-10 at 18 46 15" src="https://user-images.githubusercontent.com/20731972/145618447-6b75fb37-3989-4b5a-9aee-87700b2a9ee3.png">

